### PR TITLE
Make lollipop radius proportional to total counts

### DIFF
--- a/web/src/components/Common/CustomPlotDots.tsx
+++ b/web/src/components/Common/CustomPlotDots.tsx
@@ -35,7 +35,7 @@ export function CustomizedDot(props: CustomizedDotProps) {
 
   const freq = counts[name] / totals[name] // observed frequency
   const cy2 = height * (1 - freq) + y0 // map obs. freq. to plot region
-  const rad = 1 + AREA_FACTOR * Math.sqrt(counts[name]) // scale area to obs. count
+  const rad = AREA_FACTOR * Math.sqrt(totals[name]) // scale area to total counts in time window
 
   return (
     <>

--- a/web/src/components/Common/CustomPlotDots.tsx
+++ b/web/src/components/Common/CustomPlotDots.tsx
@@ -83,7 +83,7 @@ export function CustomizedActiveDot(props: CustomizedDotProps & { shouldShowDots
           stroke={fill}
           strokeWidth={1.5 * CIRCLE_LINEWIDTH}
           fill="#ffffff00"
-          r={1 + AREA_FACTOR * Math.sqrt(counts[name])}
+          r={AREA_FACTOR * Math.sqrt(totals[name])}
         />
       )}
       <line


### PR DESCRIPTION
Lollipop radius hence signifies statistical weight as opposed to counts
of the variant in question, which seems more intuitive to me

As a result, there's less of a trend of big lollipops at the top and
small ones at the bottom.

In particular, lollipops of non-observed variants were not shown at all - despite the fact that we do know something: that out of N observations none were of the variant in question.

Also, this PR removes the pseudocount of 1 that is added to radius - I'm not sure why this is necessary: if there is no observation, there is no lollipop anyways, so the radius will be >=1 anyways.

Before:
<img width="2137" alt="image" src="https://github.com/neherlab/flu_frequencies/assets/25161793/2a21548b-b9d2-439b-b4ca-7768ce5861de">

After:
<img width="2161" alt="image" src="https://github.com/neherlab/flu_frequencies/assets/25161793/4415a745-c380-4c63-b33a-4ef79efd83d6">


