### PR TITLE
Sort countries and variants

### DIFF
--- a/web/src/components/Common/Dropdown.tsx
+++ b/web/src/components/Common/Dropdown.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useCallback, useMemo, useState } from 'react'
 import styled from 'styled-components'
-import { rgba, darken } from 'polished'
+import { darken } from 'polished'
 import {
   Dropdown as DropdownBase,
   DropdownToggle as DropdownToggleBase,
@@ -10,25 +10,30 @@ import {
 } from 'reactstrap'
 import { MdArrowDropDown } from 'react-icons/md'
 
-export interface DropdownEntry {
-  key: string
+export interface DropdownEntry<K> {
+  key: K
   value: ReactNode
 }
 
-export interface DropdownProps extends DropdownBaseProps {
-  entries: DropdownEntry[]
-  currentEntry: DropdownEntry
-  setCurrentEntry(key: DropdownEntry): void
+export interface DropdownProps<K> extends DropdownBaseProps {
+  entries: DropdownEntry<K>[]
+  currentEntry: DropdownEntry<K>
+  setCurrentEntry(key: DropdownEntry<K>): void
 }
 
-export function Dropdown({ currentEntry, setCurrentEntry, entries, ...restProps }: DropdownProps) {
+export function Dropdown<K extends { toString(): string }>({
+  currentEntry,
+  setCurrentEntry,
+  entries,
+  ...restProps
+}: DropdownProps<K>) {
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const toggle = useCallback(() => setDropdownOpen((prevState) => !prevState), [])
-  const onClick = useCallback((entry: DropdownEntry) => () => setCurrentEntry(entry), [setCurrentEntry])
+  const onClick = useCallback((entry: DropdownEntry<K>) => () => setCurrentEntry(entry), [setCurrentEntry])
   const menuItems = useMemo(() => {
     return entries.map((entry) => {
       return (
-        <DropdownItem key={entry.key} active={entry.key === currentEntry.key} onClick={onClick(entry)}>
+        <DropdownItem key={entry.key.toString()} active={entry.key === currentEntry.key} onClick={onClick(entry)}>
           {entry.value}
         </DropdownItem>
       )
@@ -48,9 +53,10 @@ export function Dropdown({ currentEntry, setCurrentEntry, entries, ...restProps 
 
 const DropdownStyled = styled(DropdownBase)`
   display: flex;
-  border: ${(props) => rgba(props.theme.primary, 0.5)} solid 1px;
+  border: ${(props) => props.theme.gray200} solid 1px;
   border-radius: 3px;
   box-shadow: ${(props) => props.theme.shadows.lighter};
+  background-color: ${(props) => props.theme.bodyBg};
 
   color: ${(props) => props.theme.bodyColor};
 
@@ -59,7 +65,9 @@ const DropdownStyled = styled(DropdownBase)`
   }
 
   & > a {
-    // min-width: 200px;
+    width: 100%;
+    padding: 4px;
+    padding-left: 10px;
   }
 `
 
@@ -71,6 +79,13 @@ const DropdownToggle = styled(DropdownToggleBase)`
 const DropdownToggleText = styled.span`
   flex: 1;
   color: ${(props) => props.theme.bodyColor};
+
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  display: block;
+
+  max-width: 200px;
 
   :hover {
     color: ${(props) => props.theme.bodyColor};
@@ -88,10 +103,18 @@ const DropdownMenu = styled(DropdownMenuBase)`
   background-color: ${(props) => props.theme.bodyBg};
   box-shadow: ${(props) => props.theme.shadows.blurredMedium};
   max-height: 70vh;
-  overflow-y: scroll;
+  overflow-y: auto;
 `
 
 const DropdownItem = styled(DropdownItemBase)<{ active: boolean }>`
+  * {
+    white-space: nowrap;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
+  }
+
+  max-width: 70vw;
+
   :hover {
     color: ${({ active, theme }) => (active ? theme.white : theme.bodyColor)};
     background: ${({ active, theme }) => (active ? darken(0.025)(theme.primary) : theme.gray200)};

--- a/web/src/components/Layout/LanguageSwitcher.tsx
+++ b/web/src/components/Layout/LanguageSwitcher.tsx
@@ -9,9 +9,9 @@ import { FlagWrapper as FlagWrapperBase } from 'src/components/Common/CountryFla
 
 export function LanguageSwitcher({
   ...restProps
-}: Omit<DropdownProps, 'entries' | 'currentEntry' | 'setCurrentEntry'>) {
+}: Omit<DropdownProps<string>, 'entries' | 'currentEntry' | 'setCurrentEntry'>) {
   const [currentLocale, setCurrentLocale] = useRecoilState(localeAtom)
-  const setCurrentEntry = useCallback((entry: DropdownEntry) => setCurrentLocale(entry.key), [setCurrentLocale])
+  const setCurrentEntry = useCallback((entry: DropdownEntry<string>) => setCurrentLocale(entry.key), [setCurrentLocale])
 
   const { entries } = useMemo(() => {
     const entries = localesArray.map((locale) => ({

--- a/web/src/components/Layout/NavigationBreadcrumb.tsx
+++ b/web/src/components/Layout/NavigationBreadcrumb.tsx
@@ -10,7 +10,7 @@ import urljoin from 'url-join'
 import { BsCaretRightFill as ArrowRight } from 'react-icons/bs'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { Link } from 'src/components/Link/Link'
-import { useCountryName, usePathogen, useRegionsDataQuery, useVariantsDataQuery } from 'src/io/getData'
+import { useCountries, useCountryName, usePathogen, useRegions, useVariantsDataQuery } from 'src/io/getData'
 import type { DropdownOption } from 'src/components/Common/DropdownWithSearch'
 
 const paths = [
@@ -205,17 +205,18 @@ export function BreadcrumbRegionSelector({ pathogenName, region }: BreadcrumbReg
   const { t } = useTranslationSafe()
   const { push } = useRouter()
   const [value, setValue] = useState(region)
-  const { regions, countries } = useRegionsDataQuery(pathogenName)
+  const regions = useRegions(pathogenName)
+  const countries = useCountries(pathogenName)
   const getCountryName = useCountryName()
 
   const locations = useMemo(() => [...regions, ...countries], [countries, regions])
   const options = useMemo(
     () =>
-      locations.map((location) => ({
-        label: t(getCountryName(location)),
-        value: location,
+      locations.map(({ code, translated }) => ({
+        label: translated,
+        value: code,
       })),
-    [getCountryName, locations, t],
+    [locations],
   )
   const option = useMemo(() => ({ label: t(getCountryName(value)), value }), [getCountryName, t, value])
   const onChange = useCallback(

--- a/web/src/components/Regions/RegionPage.tsx
+++ b/web/src/components/Regions/RegionPage.tsx
@@ -42,7 +42,7 @@ export function RegionPage({ pathogenName, location }: RegionsPageProps) {
 
   return (
     <PageContainerHorizontal>
-      <RegionsSidebar pathogenName={pathogenName} />
+      <RegionsSidebar pathogenName={pathogenName} region={location} />
 
       <MainContent>
         <MainContentInner>

--- a/web/src/components/Regions/RegionsSidebar.tsx
+++ b/web/src/components/Regions/RegionsSidebar.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react'
+import styled from 'styled-components'
 import { useRecoilState_TRANSITION_SUPPORT_UNSTABLE as useRecoilState } from 'recoil'
 import { SearchBox } from 'src/components/Common/SearchBox'
 import { variantsSearchTermAtom } from 'src/state/geography.state'
@@ -7,18 +8,28 @@ import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
 import { SidebarSectionVariants } from 'src/components/Sidebar/SidebarSectionVariants'
 import { Sidebar, SidebarSection, SidebarSectionCollapsible } from 'src/components/Sidebar/SidebarCard'
 import { RegionsPlotSettings } from './RegionsPlotSettings'
+import { SortingCriteriaSelector } from '../Sidebar/SidebarSortVariants'
 
 export interface RegionsSidebarProps {
   pathogenName: string
+  region: string
 }
 
-export function RegionsSidebar({ pathogenName }: RegionsSidebarProps) {
+export function RegionsSidebar({ pathogenName, region }: RegionsSidebarProps) {
   const { t } = useTranslationSafe()
-  const variantsHeader = useMemo(() => <VariantsSectionHeader />, [])
+  const variantsHeader = useMemo(
+    () => (
+      <Wrapper>
+        <VariantsSectionHeader />
+        <SortingCriteriaSelector />
+      </Wrapper>
+    ),
+    [],
+  )
   return (
     <Sidebar>
       <SidebarSection header={variantsHeader}>
-        <SidebarSectionVariants pathogenName={pathogenName} />
+        <SidebarSectionVariants pathogenName={pathogenName} region={region} />
       </SidebarSection>
       <SidebarSectionCollapsible header={t('Settings')} recoilState={isSidebarSettingsCollapsedAtom}>
         <RegionsPlotSettings />
@@ -31,3 +42,9 @@ function VariantsSectionHeader() {
   const [searchTerm, setSearchTerm] = useRecoilState(variantsSearchTermAtom)
   return <SearchBox searchTitle={'Search variants'} searchTerm={searchTerm} onSearchTermChange={setSearchTerm} />
 }
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`

--- a/web/src/components/Sidebar/SidebarSectionGeography.tsx
+++ b/web/src/components/Sidebar/SidebarSectionGeography.tsx
@@ -5,11 +5,10 @@ import { useRecoilState } from 'recoil'
 import styled from 'styled-components'
 import { Form } from 'reactstrap'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { Pathogen, useCountryName, usePathogen, useRegionsDataQuery } from 'src/io/getData'
+import { Pathogen, useCountries, usePathogen, useRegions } from 'src/io/getData'
 import { fuzzySearchObj } from 'src/helpers/fuzzySearch'
 import { continentAtom, countryAtom, geographyEnableAllAtom, geographySearchTermAtom } from 'src/state/geography.state'
 import { CheckboxIndeterminateWithText, CheckboxWithIcon } from 'src/components/Common/Checkbox'
-import { transliterate } from 'transliteration'
 
 const GeoIconCountry = dynamic(() => import('src/components/Common/GeoIconCountry').then((m) => m.GeoIconCountry))
 const GeoIconContinent = dynamic(() => import('src/components/Common/GeoIconContinent').then((m) => m.GeoIconContinent))
@@ -24,29 +23,16 @@ export interface SidebarSectionGeographyProps {
 }
 
 export function SidebarSectionGeography({ pathogenName }: SidebarSectionGeographyProps) {
-  const { t } = useTranslationSafe()
   const pathogen = usePathogen(pathogenName)
-  const { countries, regions } = useRegionsDataQuery(pathogen.name)
   const [searchTerm] = useRecoilState(geographySearchTermAtom)
-  const getCountryName = useCountryName()
+  const regionsTranslated = useRegions(pathogenName)
+  const countriesTranslated = useCountries(pathogenName)
 
   const checkboxes = useMemo(() => {
-    const regionsTranslated = regions.map((region) => {
-      const translated = t(region)
-      const transliterated = transliterate(translated)
-      return { region, translated, transliterated }
-    })
-    const countriesTranslated = countries.map((code) => {
-      const name = getCountryName(code)
-      const translated = t(name)
-      const transliterated = transliterate(translated)
-      return { code, name, translated, transliterated }
-    })
-
     const scored = [
-      ...fuzzySearchObj(regionsTranslated, ['region', 'translated', 'transliterated'], searchTerm).map(
-        ({ item: { region }, score }) => ({
-          component: <ContinentCheckbox key={region} continent={region} pathogenName={pathogenName} />,
+      ...fuzzySearchObj(regionsTranslated, ['name', 'translated', 'transliterated'], searchTerm).map(
+        ({ item: { name }, score }) => ({
+          component: <ContinentCheckbox key={name} continent={name} pathogenName={pathogenName} />,
           score,
         }),
       ),
@@ -65,7 +51,7 @@ export function SidebarSectionGeography({ pathogenName }: SidebarSectionGeograph
     }
 
     return checkboxes
-  }, [countries, getCountryName, pathogen, pathogenName, regions, searchTerm, t])
+  }, [countriesTranslated, pathogen, pathogenName, regionsTranslated, searchTerm])
 
   return (
     <Container>

--- a/web/src/components/Sidebar/SidebarSectionVariants.tsx
+++ b/web/src/components/Sidebar/SidebarSectionVariants.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { ColoredBox } from 'src/components/Common/ColoredBox'
 import { fuzzySearch } from 'src/helpers/fuzzySearch'
 import { useTranslationSafe } from 'src/helpers/useTranslationSafe'
-import { Pathogen, usePathogen, useVariantsDataQuery, useVariantStyle } from 'src/io/getData'
+import { Pathogen, usePathogen, useVariants, useVariantStyle } from 'src/io/getData'
 import { variantsSearchTermAtom } from 'src/state/geography.state'
 import { variantAtom, variantsEnableAllAtom } from 'src/state/variants.state'
 import { CheckboxIndeterminateWithText, CheckboxWithIcon } from 'src/components/Common/Checkbox'
@@ -18,11 +18,12 @@ const Container = styled.div`
 
 export interface SidebarSectionVariantsProps {
   pathogenName: string
+  region: string
 }
 
-export function SidebarSectionVariants({ pathogenName }: SidebarSectionVariantsProps) {
+export function SidebarSectionVariants({ pathogenName, region }: SidebarSectionVariantsProps) {
   const pathogen = usePathogen(pathogenName)
-  const { variants } = useVariantsDataQuery(pathogenName)
+  const variants = useVariants(pathogenName, region)
   const [searchTerm] = useRecoilState(variantsSearchTermAtom)
   const checkboxes = useMemo(() => {
     const checkboxes = fuzzySearch(variants, searchTerm).map(({ item }) => (

--- a/web/src/components/Sidebar/SidebarSortVariants.tsx
+++ b/web/src/components/Sidebar/SidebarSortVariants.tsx
@@ -1,0 +1,91 @@
+import { VariantsSortingBy, variantsSortingCriteriaAtom } from 'src/state/settings.state'
+import { TFunction, useTranslationSafe } from 'src/helpers/useTranslationSafe'
+import { ErrorInternal } from 'src/helpers/ErrorInternal'
+import { useRecoilState } from 'recoil'
+import React, { useCallback, useMemo } from 'react'
+import { Dropdown as DropdownBase, DropdownEntry } from 'src/components/Common/Dropdown'
+import styled from 'styled-components'
+import { FormGroup as FormGroupBase } from 'reactstrap'
+
+function getSortingString(key: VariantsSortingBy, t: TFunction): string {
+  switch (key) {
+    case VariantsSortingBy.Name: {
+      return t('Name')
+    }
+    case VariantsSortingBy.Frequency: {
+      return t('Frequency')
+    }
+    default: {
+      throw new ErrorInternal('getSortingString: unexpected value for enum')
+    }
+  }
+}
+
+export function SortingCriteriaSelector() {
+  const { t } = useTranslationSafe()
+  const [sorting, setSorting] = useRecoilState(variantsSortingCriteriaAtom)
+
+  const setCurrentEntry = useCallback(
+    (entry: DropdownEntry<VariantsSortingBy>) => {
+      setSorting(entry.key)
+    },
+    [setSorting],
+  )
+
+  const { entries } = useMemo(() => {
+    const entries = Object.values(VariantsSortingBy).map((key) => {
+      const value = getSortingString(key, t)
+      return {
+        key,
+        value: (
+          <span key={key} title={value}>
+            {value}
+          </span>
+        ),
+      }
+    })
+    return { entries }
+  }, [t])
+
+  const currentEntry = useMemo(() => {
+    const e = entries.find((entry) => entry.key === sorting)
+    if (!e) {
+      throw new ErrorInternal(`Not found: '${e}'`)
+    }
+
+    return { key: e.key, value: e.value }
+  }, [entries, sorting])
+
+  const label = t('Sort by')
+
+  return (
+    <FormGroup>
+      <LabelText title={label}>{label}</LabelText>
+      <Dropdown entries={entries} currentEntry={currentEntry} setCurrentEntry={setCurrentEntry} />
+    </FormGroup>
+  )
+}
+
+const FormGroup = styled(FormGroupBase)`
+  display: flex !important;
+  margin: 0;
+  margin-top: 0.5rem;
+`
+
+const Dropdown = styled(DropdownBase)`
+  flex: 0 0 150px;
+  vertical-align: middle;
+  margin: 0;
+`
+
+const LabelText = styled.span`
+  flex: 1;
+
+  vertical-align: middle;
+  margin: auto 0;
+  margin-right: 5px;
+
+  white-space: nowrap;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+`

--- a/web/src/helpers/useTranslationSafe.ts
+++ b/web/src/helpers/useTranslationSafe.ts
@@ -3,8 +3,10 @@ import { isString } from 'lodash-es'
 import type { TOptions } from 'i18next'
 import { useTranslation } from 'react-i18next'
 
+export type TFunction = (key: string, options?: Record<string, unknown>) => string
+
 export interface UseTranslationSafeResult {
-  t: (key: string, options?: Record<string, unknown>) => string
+  t: TFunction
 }
 
 export function useTranslationSafe(): UseTranslationSafeResult {

--- a/web/src/state/settings.state.ts
+++ b/web/src/state/settings.state.ts
@@ -30,3 +30,14 @@ export const isSidebarSettingsCollapsedAtom = atom({
   default: false,
   effects: [persistAtom],
 })
+
+export enum VariantsSortingBy {
+  Name = 'Name',
+  Frequency = 'Frequency',
+}
+
+export const variantsSortingCriteriaAtom = atom<VariantsSortingBy>({
+  key: 'variantsSortingCriteriaAtom',
+  default: VariantsSortingBy.Name,
+  effects: [persistAtom],
+})


### PR DESCRIPTION
Followup of #28 

- [x] Statically sort countries and regions by their localized names in all lists (selector list on the pathogen's page, sidebar checkboxes, dropdown selector in the breadcrumb).
- [x] Allow to toggle variants sorting in the sidebar either by name or by the last average frequency. In all other places variants are sorted by name.

Merge only after https://github.com/nextstrain/flu_frequencies/pull/28 is merged!

https://github.com/nextstrain/flu_frequencies/assets/9403403/6638cb7f-750b-4c44-b16d-00b2d318c6ba



