### PR TITLE
Version nextclade binary for transition, i.e. nextclade -> nextclade2

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -107,7 +107,7 @@ rule get_nextclade_dataset:
     threads: 4
     shell:
         """
-        nextclade dataset get -n flu_{wildcards.lineage}_{wildcards.segment} --output-dir nextclade/{wildcards.lineage}_{wildcards.segment}
+        nextclade2 dataset get -n flu_{wildcards.lineage}_{wildcards.segment} --output-dir nextclade/{wildcards.lineage}_{wildcards.segment}
         """
 
 
@@ -120,7 +120,7 @@ rule run_nextclade:
     threads: workflow.cores
     shell:
         """
-        nextclade run -j {threads} -D nextclade/{wildcards.lineage}_{wildcards.segment} \
+        nextclade2 run -j {threads} -D nextclade/{wildcards.lineage}_{wildcards.segment} \
                   {input.sequences} --quiet --output-tsv {output}
         """
 


### PR DESCRIPTION
Soon we will release nextclade v3. Once nextclade v3 hits bioconda, workflows that rely on v2 syntax will break. To prevent this, this PR makes it explicit that the syntax used is for v2 and that the v2 binary nextclade2 should be used.

This binary is in both the nextstrain-base docker image and in the conda-base managed conda environment.

Users who don't use either will have to add nextclade2 to the path.

Over the next few weeks, we will transition repos to use nextclade3. The reason to add nextclade2 now is so that workflows don't break if they haven't yet transitioned to nextclade3 at the time of v3 release. It also makes it easy to search which workflows need to be changed.
