### PR TITLE
Download Nextclade TSV from S3

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -52,6 +52,16 @@ rule download_sequences:
         aws s3 cp {params.s3_path} - | xz -c -d > {output.sequences}
         """
 
+rule download_nextclade:
+    output:
+        nextclade="data/{lineage}/nextclade_{segment}.tsv",
+    params:
+        s3_path="s3://nextstrain-data-private/files/workflows/seasonal-flu/{lineage}/{segment}/nextclade.tsv.xz",
+    shell:
+        """
+        aws s3 cp {params.s3_path} - | xz -c -d > {output.nextclade}
+        """
+
 rule download_metadata:
     output:
         metadata="data/{lineage}/metadata_raw_{segment}.tsv",
@@ -83,30 +93,6 @@ rule add_iso3:
             --append-fields continent \
             --write-all="?" \
             > {output.metadata}
-        """
-
-
-rule get_nextclade_dataset:
-    output:
-        "nextclade/{lineage}_{segment}/reference.fasta",
-    threads: 1
-    shell:
-        """
-        nextclade3 dataset get -n flu_{wildcards.lineage}_{wildcards.segment} --output-dir nextclade/{wildcards.lineage}_{wildcards.segment}
-        """
-
-
-rule run_nextclade:
-    input:
-        sequences="data/{lineage}/{segment}.fasta",
-        reference="nextclade/{lineage}_{segment}/reference.fasta",
-    output:
-        "data/{lineage}/nextclade_{segment}.tsv",
-    threads: workflow.cores
-    shell:
-        """
-        nextclade3 run -j {threads} -D nextclade/{wildcards.lineage}_{wildcards.segment} \
-                  {input.sequences} --quiet --output-tsv {output}
         """
 
 


### PR DESCRIPTION
## Description of proposed changes

Instead of running Nextclade on all sequences per lineage, download Nextclade TSVs from S3 where they have been uploaded as part of the corresponding seasonal-flu repo's GitHub Action [1]. With this change, frequency estimation for all flu lineages takes less than 1 minute on 8 CPUs.

[1] https://github.com/nextstrain/seasonal-flu/actions/workflows/run-nextclade.yaml

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Tested locally
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
